### PR TITLE
Fix prog_name comment

### DIFF
--- a/valtool.py
+++ b/valtool.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env/python
 #coding: utf8 
 #
-#prog_name= 'pintool.py'
+#prog_name= 'valtool.py'
 #prog_version = '0.2'
 #prog_release = '20151028'
 #prog_author = 'Eduardo Garcia Melia'


### PR DESCRIPTION
## Summary
- correct the prog_name comment to match file name

## Testing
- `python3 -m py_compile valtool.py` *(fails: SyntaxError)*

------
https://chatgpt.com/codex/tasks/task_e_684008931cb483209bfa181faaf4f061