### PR TITLE
Fix typographical error in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This tool can be useful for solving some reversing challenges in CTFs events. Im
 
 
 ### Configuration
-You must have the lastest installation of Valgrind
+You must have the latest installation of Valgrind
 
 ### Help
 


### PR DESCRIPTION
## Summary
- fix 'lastest' typo in the README configuration section

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68400891766083209d235f5875390355