### PR TITLE
Fix shebang in valtool script

### DIFF
--- a/valtool.py
+++ b/valtool.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env/python
+#!/usr/bin/env python
 #coding: utf8 
 #
 #prog_name= 'pintool.py'


### PR DESCRIPTION
## Summary
- fix shebang in `valtool.py` to use `/usr/bin/env python`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840088efdd8832096c96d8c58e56024